### PR TITLE
Supabase: Server-timed turns and island UI visibility (hide other-island fields & manual turn)

### DIFF
--- a/Supabase/README.md
+++ b/Supabase/README.md
@@ -5,4 +5,4 @@
 3. Edge Function に `SUPABASE_URL` と `SUPABASE_SERVICE_ROLE_KEY` を設定します。
 4. `main.html` の `SUPABASE_URL` と `SUPABASE_ANON_KEY` だけを実プロジェクト値に変更します。
 
-ターン間隔は `turn.js` の `TURN_INTERVAL_MS` で変更できます。初期値は5分です。
+ターン間隔は `turn.js` の `TURN_INTERVAL_MS` で変更できます。初期値は5分です。ターンのカウントダウンと進行判定は `schema.sql` の `hakoniwa_server_timestamp()` で取得したSupabaseサーバー時刻に同期します。

--- a/Supabase/main.js
+++ b/Supabase/main.js
@@ -38,9 +38,34 @@ export function startSupabaseHakoniwa(config) {
     onTurnComplete: async () => {
       await refreshIslandLists();
       const session = store.getSession();
-      if (session) await store.login({ serial: session.serial, password: session.password });
+      if (session) {
+        await store.login({ serial: session.serial, password: session.password });
+        showOwnIslandView();
+      }
     }
   });
+
+
+  function setGameAreaVisibility({ showPlans, showMap, showQueue }) {
+    const planControls = $('planControls');
+    const map = $('map');
+    const actionQueueDisplay = $('actionQueueDisplay');
+    if (planControls) planControls.style.display = showPlans ? '' : 'none';
+    if (map) map.style.display = showMap ? '' : 'none';
+    if (actionQueueDisplay) actionQueueDisplay.style.display = showQueue ? '' : 'none';
+  }
+
+  function showOwnIslandView() {
+    setGameAreaVisibility({ showPlans: true, showMap: true, showQueue: true });
+  }
+
+  function showTouristView() {
+    setGameAreaVisibility({ showPlans: true, showMap: true, showQueue: false });
+  }
+
+  function hideIslandView() {
+    setGameAreaVisibility({ showPlans: false, showMap: false, showQueue: false });
+  }
 
   async function refreshIslandLists() {
     const islands = await store.listIslands();
@@ -71,6 +96,7 @@ export function startSupabaseHakoniwa(config) {
       });
       $('supabaseSerialInput').value = serial;
       setStatus(`登録完了: 通し番号 No.${serial} が発行されました。`);
+      showOwnIslandView();
       await refreshIslandLists();
     } catch (error) {
       setStatus(`登録失敗: ${error.message}`);
@@ -84,6 +110,7 @@ export function startSupabaseHakoniwa(config) {
         password: $('supabasePasswordInput').value
       });
       setStatus(`ログイン中: No.${island.serial} ${island.islandName}`);
+      showOwnIslandView();
       await refreshIslandLists();
     } catch (error) {
       setStatus(`ログイン失敗: ${error.message}`);
@@ -102,6 +129,7 @@ export function startSupabaseHakoniwa(config) {
 
   $('supabaseLogoutBtn').addEventListener('click', () => {
     store.logout();
+    hideIslandView();
     setStatus('ログアウトしました（観光者モード可）。');
   });
 
@@ -110,6 +138,7 @@ export function startSupabaseHakoniwa(config) {
       const serial = $('supabaseTouristIslandSelect').value;
       if (!serial) throw new Error('観光する島を選択してください。');
       const island = await store.loadTourist(serial);
+      showTouristView();
       setStatus(`観光者モード: No.${island.serial} ${island.islandName}`);
     } catch (error) {
       setStatus(`観光失敗: ${error.message}`);
@@ -117,14 +146,21 @@ export function startSupabaseHakoniwa(config) {
   });
 
   $('supabaseReturnBtn').addEventListener('click', () => {
-    store.returnHome();
-    setStatus('自島に戻りました。');
+    const returned = store.returnHome();
+    if (returned) {
+      showOwnIslandView();
+      setStatus('自島に戻りました。');
+    } else {
+      hideIslandView();
+      setStatus('ログインしていないため、自島の表示を隠しました。');
+    }
   });
 
   $('supabaseOtherIslandSelect').addEventListener('change', async (event) => {
     if (!event.target.value) return;
     try {
       await store.loadTourist(event.target.value);
+      showTouristView();
       setStatus('行き先の島を観光者モードで表示しました。砲撃系計画のみ登録できます。');
     } catch (error) {
       setStatus(`行き先表示失敗: ${error.message}`);
@@ -140,7 +176,10 @@ export function startSupabaseHakoniwa(config) {
         return;
       }
       store.loadTourist(serial)
-        .then((island) => setStatus(`観光者モード: No.${island.serial} ${island.islandName}`))
+        .then((island) => {
+          showTouristView();
+          setStatus(`観光者モード: No.${island.serial} ${island.islandName}`);
+        })
         .catch((error) => setStatus(`行き先表示失敗: ${error.message}`));
       $('actionSelect').value = '';
       window.updateConfirmButton();
@@ -158,6 +197,7 @@ export function startSupabaseHakoniwa(config) {
     if (shouldShow) $('touristCodeInput').style.display = 'none';
   };
 
+  hideIslandView();
   scheduler.start();
   refreshIslandLists().catch((error) => setStatus(`島一覧取得失敗: ${error.message}`));
   $('supabaseTurnIntervalLabel').textContent = `${Math.round(TURN_INTERVAL_MS / 60000)}分`;

--- a/Supabase/schema.sql
+++ b/Supabase/schema.sql
@@ -92,6 +92,16 @@ begin
 end;
 $$;
 
+create or replace function public.hakoniwa_server_timestamp()
+returns bigint
+language sql
+volatile
+security definer
+set search_path = public
+as $$
+  select floor(extract(epoch from clock_timestamp()) * 1000)::bigint;
+$$;
+
 alter table public.hakoniwa_islands enable row level security;
 
 drop policy if exists "public tourist read" on public.hakoniwa_islands;
@@ -102,3 +112,4 @@ grant select on public.hakoniwa_public_islands to anon, authenticated;
 grant execute on function public.hakoniwa_register(text, text, jsonb) to anon, authenticated;
 grant execute on function public.hakoniwa_login(bigint, text) to anon, authenticated;
 grant execute on function public.hakoniwa_save(bigint, text, jsonb, boolean) to anon, authenticated;
+grant execute on function public.hakoniwa_server_timestamp() to anon, authenticated;

--- a/Supabase/state.js
+++ b/Supabase/state.js
@@ -85,8 +85,13 @@ export function createStateStore(supabase, core) {
 
   function returnHome() {
     if (!currentState && session) currentState = core.getState();
-    if (currentState) core.setOwnIsland(currentState);
+    if (!currentState) {
+      viewingIsland = null;
+      return false;
+    }
+    core.setOwnIsland(currentState);
     viewingIsland = null;
+    return true;
   }
 
   function queueRemoteBombard({ action, count, x, y }) {

--- a/Supabase/turn.js
+++ b/Supabase/turn.js
@@ -1,43 +1,81 @@
 export const TURN_INTERVAL_MS = 5 * 60 * 1000;
 
-export function createTurnScheduler({ supabase, store, core, onTick, onTurnComplete }) {
+export function createTurnScheduler({ supabase, core, onTick, onTurnComplete }) {
   let timerId = null;
-  let nextTurnAt = Date.now() + TURN_INTERVAL_MS;
   let running = false;
+  let serverOffsetMs = 0;
+  let lastServerSyncAt = 0;
+  let lastProcessedSlot = null;
+  let warnedServerTimeFallback = false;
+  const SERVER_SYNC_INTERVAL_MS = 60 * 1000;
 
-  function remainingMs() {
-    return Math.max(0, nextTurnAt - Date.now());
+  function serverNow() {
+    return Date.now() + serverOffsetMs;
   }
 
-  async function runServerTurn() {
-    if (running) return;
+  function currentSlot() {
+    return Math.floor(serverNow() / TURN_INTERVAL_MS);
+  }
+
+  function remainingMs() {
+    const nextTurnAt = (currentSlot() + 1) * TURN_INTERVAL_MS;
+    return Math.max(0, nextTurnAt - serverNow());
+  }
+
+  async function syncServerTime() {
+    try {
+      const { data, error } = await supabase.rpc('hakoniwa_server_timestamp');
+      if (error) throw error;
+      const serverMs = Number(data);
+      if (!Number.isFinite(serverMs)) throw new Error('invalid server timestamp');
+      serverOffsetMs = serverMs - Date.now();
+      lastServerSyncAt = Date.now();
+    } catch (error) {
+      lastServerSyncAt = Date.now();
+      if (!warnedServerTimeFallback) {
+        warnedServerTimeFallback = true;
+        core.logAction(`サーバー時刻の取得に失敗したため端末時刻で表示します: ${error.message || error}`);
+      }
+    }
+  }
+
+  async function ensureServerTimeFresh() {
+    if (Date.now() - lastServerSyncAt < SERVER_SYNC_INTERVAL_MS) return;
+    await syncServerTime();
+  }
+
+  async function runServerTurn(slot = currentSlot()) {
+    if (running || lastProcessedSlot === slot) return;
     running = true;
+    lastProcessedSlot = slot;
     try {
       const { error } = await supabase.functions.invoke('hakoniwa-turn-worker', {
         body: { inactiveTurnLimit: 50 }
       });
       if (error) throw error;
     } catch (error) {
-      // Edge Function 未デプロイ時でも開発確認できるよう、ログイン中の島だけクライアント側で進行する。
-      if (store.getSession()) {
-        core.logAction(`サーバーターン関数を呼び出せなかったため、この島のみフォールバック進行します: ${error.message || error}`);
-        core.nextTurn();
-        await store.saveCurrent({ markAction: false });
-      } else {
-        core.logAction(`サーバーターン関数を呼び出せませんでした: ${error.message || error}`);
-      }
+      core.logAction(`サーバーターン関数を呼び出せませんでした: ${error.message || error}`);
     } finally {
-      nextTurnAt = Date.now() + TURN_INTERVAL_MS;
       running = false;
+      await syncServerTime();
       if (typeof onTurnComplete === 'function') await onTurnComplete();
     }
   }
 
   function start() {
     stop();
-    timerId = window.setInterval(async () => {
+    syncServerTime().finally(() => {
+      lastProcessedSlot = currentSlot();
       if (typeof onTick === 'function') onTick(remainingMs(), TURN_INTERVAL_MS);
-      if (remainingMs() <= 0) await runServerTurn();
+    });
+    timerId = window.setInterval(async () => {
+      await ensureServerTimeFresh();
+      const remaining = remainingMs();
+      if (typeof onTick === 'function') onTick(remaining, TURN_INTERVAL_MS);
+      const slot = currentSlot();
+      if (slot !== lastProcessedSlot) {
+        await runServerTurn(slot);
+      }
     }, 1000);
     if (typeof onTick === 'function') onTick(remainingMs(), TURN_INTERVAL_MS);
   }

--- a/main.html
+++ b/main.html
@@ -106,14 +106,8 @@ SOFTWARE. -->
     </div>
 </p></details>
 <p>陸地面積: <span id="landArea">0</span>Km² | 砲撃可能数上限: <span id="gunCount">0</span>回 | 実績Pt: <span id="achievementPoints">0</span>Pt<br>資金: <span id="money">1000</span>G | 食料: <span id="food">500</span> | 人口: <span id="population">0</span>人 | ターン: <span id="turn">0</span> | 島の名前: <span id="currentIslandName"></span></p>
-<div>
-    <label for="otherIslandActionInput">他島の行動:</label>
-    <input type="text" id="otherIslandActionInput" style="width: 400px; margin-bottom: 5px;" placeholder="ここに他島からの行動を入力してください">
-</div>
-<div>
-    <label for="actionForOtherIslandOutput">他島への行動:</label>
-    <input type="text" id="actionForOtherIslandOutput" style="width: 400px; margin-bottom: 5px;" readonly>
-</div>
+<input type="hidden" id="otherIslandActionInput" value="">
+<input type="hidden" id="actionForOtherIslandOutput" value="">
 <div style="margin-top: 2px;">
     <span id="keepOptionSettingControl">
       <input type="checkbox" id="keepOptionSelected">
@@ -125,8 +119,7 @@ SOFTWARE. -->
       <label for="pinFundingFailureTracking">トラッキングを固定</label>
     </span>
 </div>
-<button onclick="nextTurn()">▶ ターンを進める</button>
-<br>
+<div id="planControls">
 <select id="actionSelect" onchange="updateConfirmButton()">
   <option value="">計画一覧</option>
   <option value="buildFarm" data-myisland="true">農場建設 (100G)</option>
@@ -227,6 +220,7 @@ SOFTWARE. -->
 <button onclick="confirmAction()" id="confirmBtn" disabled>決定</button>
 <button onclick="clearTileSelection()" id="clearTileSelectionBtn" style="display: none;">タイル選択の解除</button>
 <span id="tileInfo"></span>
+</div>
 <div id="gameContainer" style="display: flex; gap: 5px;">
     <table id="map"></table>
     <div id="actionQueueDisplay" style="font-size: 0.7em;margin-top: 1em; border: 1px solid #ccc; padding: 10px; background-color: #f9f9f9;">


### PR DESCRIPTION
### Motivation
- Remove legacy visible controls for cross-island action exchange and manual client-side turn button while keeping compatibility for encoded action data.  
- Ensure turn countdown and progression are based on Supabase server time to avoid client clock desync and duplicate progress.  
- When viewing another island (tourist mode) or when not logged in, hide plan-related UI so users cannot see or edit plans unintentionally.

### Description
- Reworked `main.html` to remove visible `他島の行動` / `他島への行動` inputs and the manual `nextTurn()` button and grouped the plan controls under `planControls`, leaving hidden inputs for compatibility (`otherIslandActionInput`, `actionForOtherIslandOutput`).  
- Added visibility helpers in `Supabase/main.js` (`setGameAreaVisibility`, `showOwnIslandView`, `showTouristView`, `hideIslandView`) and wired them to login/visit/logout/return actions so that: own-island shows plans/map/queue, tourist mode hides the action queue, and logout or return-to-own when not logged hides plans/map/queue.  
- Updated `Supabase/state.js` `returnHome()` to return a boolean indicating success so the UI can decide whether to show or hide the island view.  
- Replaced client-side turn timing with server-synced scheduling in `Supabase/turn.js`: added `hakoniwa_server_timestamp()` RPC sync, compute turn slots from server time, avoid reprocessing the same slot, and removed the previous client-side fallback that advanced the local island when the Edge Function was unreachable.  
- Added `hakoniwa_server_timestamp()` SQL function to `Supabase/schema.sql` and granted execute rights, and updated `Supabase/README.md` to document server-time synchronization.

### Testing
- Syntax/type checks: `node --check Supabase/main.js && node --check Supabase/state.js && node --check Supabase/turn.js && node --check script.js` — succeeded.  
- Sanity grep to confirm removal of visible elements: verified no visible `<label for="otherIslandActionInput">` / `<label for="actionForOtherIslandOutput">` or `nextTurn()` button remain in `main.html` — succeeded.  
- `git diff --check` returned clean results — succeeded.  
- Served `main.html` locally and fetched headers with `curl -I http://127.0.0.1:8000/main.html` to verify output served — succeeded.  
- Browser-based screenshot/testing was not performed because Playwright/Puppeteer and a browser binary were not available in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a18ea4f3e908324a365161ee6168846)