### PR TITLE
Add "詳細情報提示" warship tool to display selected warship stats immediately

### DIFF
--- a/index.html
+++ b/index.html
@@ -142,6 +142,7 @@ SOFTWARE. -->
   <option value="resupplyWarshipAmmo" data-myisland="true">弾薬補給</option>
   <option value="repairWarship" data-myisland="true">軍艦修理</option>
   <option value="setWarshipNickname" data-myisland="true">二つ名指定 (100000G)</option>
+  <option value="showWarshipDetails" data-myisland="true">詳細情報提示</option>
   <option value="convertAchievementToExp" data-myisland="true">実績pt変換</option>
   <option value="remodelWarshipWeapon" data-myisland="true">武器換装</option>
   <option value="enhanceWarship" data-myisland="true">軍艦増強</option>

--- a/script.js
+++ b/script.js
@@ -277,7 +277,7 @@ function getActionName(action, x, y, extraData) {
         goToOtherIsland: '他の島に行く', returnToMyIsland: '自島に戻る', buildWarship: '軍艦建造',
         refuelWarship: '燃料補給', resupplyWarshipAmmo: '弾薬補給', repairWarship: '軍艦修理',
         enhanceWarship: '軍艦増強', decommissionWarship: '軍艦除籍', dispatchWarship: '軍艦派遣',
-        requestWarshipReturn: '軍艦帰還要請', setWarshipNickname: '二つ名指定', convertAchievementToExp: '実績pt変換', remodelWarshipWeapon: '武器換装', buildMonument: '石碑建設', upgradeMonument: '石碑強化',
+        requestWarshipReturn: '軍艦帰還要請', setWarshipNickname: '二つ名指定', showWarshipDetails: '詳細情報提示', convertAchievementToExp: '実績pt変換', remodelWarshipWeapon: '武器換装', buildMonument: '石碑建設', upgradeMonument: '石碑強化',
         sellMonument: '石碑売却', initializeIsland: '島の初期化', delayAction: '遅延行動' 
     };
     name = actionNames[action] || action;
@@ -360,6 +360,16 @@ function setElementDisplayById(elementId, isVisible, displayValue = '') {
 function getSelectedTileWarship() {
     if (selectedX === null || selectedY === null) return null;
     return warships.find(ship => ship.x === selectedX && ship.y === selectedY) || null;
+}
+function logSelectedWarshipDetails() {
+    const warship = getSelectedTileWarship();
+    if (!warship) {
+        logAction(`選択したタイルに軍艦がいません。`);
+        return false;
+    }
+    ensureWarshipFields(warship);
+    logAction(`軍艦「${getWarshipDisplayName(warship)}」の詳細情報: 主砲 ${warship.mainGun} / 魚雷 ${warship.torpedo} / 対空砲 ${warship.antiAir} / 偵察機 ${warship.reconnaissance} / 射撃精度 ${warship.accuracyImprovement}`);
+    return true;
 }
 function getMaxExportFoodAmount() {
     return Math.max(1, Math.floor(food / 20));
@@ -1632,6 +1642,18 @@ window.confirmAction = function () {
         return;
     }
   const targetTileSelected = (selectedX !== null && selectedY !== null);
+  if (action === 'showWarshipDetails') {
+      if (!targetTileSelected) {
+          logAction(`詳細情報を提示する軍艦のタイルを選択してください。`);
+          return;
+      }
+      logSelectedWarshipDetails();
+      if (!document.getElementById('keepOptionSelected').checked) {
+          document.getElementById('actionSelect').value = "";
+      }
+      updateConfirmButton();
+      return;
+  }
   const MAX_QUEUE_SIZE = 20;
     if (actionQueue.length >= MAX_QUEUE_SIZE) {
         logAction(`計画キューが満杯です（最大${MAX_QUEUE_SIZE}個）。`);


### PR DESCRIPTION
### Motivation
- Provide a quick, no-queue way for players to inspect a selected warship's internal stats (主砲, 魚雷, 対空砲, 偵察機, 射撃精度) from the "軍艦ツール" menu. 

### Description
- Added a new sub-option `showWarshipDetails` (label: "詳細情報提示") to the warship tool menu in `index.html` so it can be selected from the UI. 
- Added `showWarshipDetails` to the action name map in `script.js` to unify its label with other actions. 
- Implemented `logSelectedWarshipDetails()` in `script.js` to read the selected tile's warship fields, ensure defaults via `ensureWarshipFields()`, and immediately call `logAction()` with the warship's main gun, torpedo, anti-air, reconnaissance and accuracy values. 
- Modified `confirmAction()` in `script.js` to branch on `showWarshipDetails` before any action-queue logic so the detail display runs immediately and does not enqueue a plan, and to clear the action selection according to the keep-option setting. 

### Testing
- Ran `node --check script.js` to verify syntax and it succeeded. 
- Executed a Python-based static assertion script that checked HTML/JS wiring and ensured the `showWarshipDetails` branch does not push to `actionQueue`, and it passed. 
- Ran `git diff --check` to validate diffs and formatting and it produced no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a28cf1ef1408324b5a074d57d5f4eef)