### PR TITLE
Add MySave gzip manual saves and optional tile re-click confirm setting

### DIFF
--- a/index.html
+++ b/index.html
@@ -59,6 +59,7 @@ SOFTWARE. -->
       <label><input type="checkbox" id="settingShowFundingTrackingControls">「トラッキング解除」「トラッキングを固定」を表示する</label>
       <label><input type="checkbox" id="settingShowEconomicCrisisRate">「経済危機発生率」を表示する</label>
       <label><input type="checkbox" id="settingEnablePlanTracking">「計画トラッキング」を実行し、表示する</label>
+      <label><input type="checkbox" id="settingConfirmOnSelectedTileClick">計画一覧で選択中に選択済みタイルを再クリックしたら決定する</label>
       <label><input type="checkbox" id="settingEnhanceWarshipToExpLimit">軍艦増強を実行したとき、経験値の限界まで実行する</label>
       <label><input type="checkbox" id="settingAutoBombardCountToGuns">砲撃数を選択したとき入力される値は常に可能台数に合わせる</label>
       <label><input type="checkbox" id="settingAutoExportFoodMax">食料輸出を選択したとき入力される値は常に限界値にする</label>

--- a/online.html
+++ b/online.html
@@ -77,6 +77,7 @@ SOFTWARE. -->
       <label><input type="checkbox" id="settingShowFundingTrackingControls">「トラッキング解除」「トラッキングを固定」を表示する</label>
       <label><input type="checkbox" id="settingShowEconomicCrisisRate">「経済危機発生率」を表示する</label>
       <label><input type="checkbox" id="settingEnablePlanTracking">「計画トラッキング」を実行し、表示する</label>
+      <label><input type="checkbox" id="settingConfirmOnSelectedTileClick">計画一覧で選択中に選択済みタイルを再クリックしたら決定する</label>
       <label><input type="checkbox" id="settingEnhanceWarshipToExpLimit">軍艦増強を実行したとき、経験値の限界まで実行する</label>
       <label><input type="checkbox" id="settingAutoBombardCountToGuns">砲撃数を選択したとき入力される値は常に可能台数に合わせる</label>
       <label><input type="checkbox" id="settingAutoExportFoodMax">食料輸出を選択したとき入力される値は常に限界値にする</label>

--- a/src/main.js
+++ b/src/main.js
@@ -152,12 +152,59 @@ function updatePublicKeyDisplay() {
       settingShowFundingTrackingControls: false,
       settingShowEconomicCrisisRate: false,
       settingEnablePlanTracking: false,
+      settingConfirmOnSelectedTileClick: false,
       settingEnhanceWarshipToExpLimit: false,
       settingAutoBombardCountToGuns: false,
       settingAutoExportFoodMax: false,
       settingAutoSupplyMax: false
   };
   let sessionSettings = { ...SESSION_SETTING_DEFAULTS };
+
+const MANUAL_SAVE_PREFIX = 'MySave:';
+function bytesToBase64(bytes) {
+    let binary = '';
+    const chunkSize = 0x8000;
+    for (let i = 0; i < bytes.length; i += chunkSize) {
+        binary += String.fromCharCode(...bytes.subarray(i, i + chunkSize));
+    }
+    return btoa(binary);
+}
+function base64ToBytes(base64) {
+    const binary = atob(base64);
+    const bytes = new Uint8Array(binary.length);
+    for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+    return bytes;
+}
+async function gzipText(text) {
+    if (typeof CompressionStream !== 'function') {
+        throw new Error('CompressionStream is not available in this browser.');
+    }
+    const stream = new Blob([text]).stream().pipeThrough(new CompressionStream('gzip'));
+    return new Uint8Array(await new Response(stream).arrayBuffer());
+}
+async function gunzipText(bytes) {
+    if (typeof DecompressionStream !== 'function') {
+        throw new Error('DecompressionStream is not available in this browser.');
+    }
+    const stream = new Blob([bytes]).stream().pipeThrough(new DecompressionStream('gzip'));
+    return await new Response(stream).text();
+}
+async function encodeManualSaveText(jsonString) {
+    return MANUAL_SAVE_PREFIX + bytesToBase64(await gzipText(jsonString));
+}
+async function decodeManualSaveText(saveText) {
+    const encodedData = saveText.trim();
+    if (encodedData.startsWith(MANUAL_SAVE_PREFIX)) {
+        const payload = encodedData.slice(MANUAL_SAVE_PREFIX.length);
+        return await gunzipText(base64ToBytes(payload));
+    }
+    if (encodedData.includes(',')) {
+        const charCodes = encodedData.split(',').map(Number);
+        return String.fromCharCode(...charCodes);
+    }
+    return decodeURIComponent(atob(encodedData));
+}
+
 
   // 軍艦の色変化条件
   const WARSHIP_CAPS = {
@@ -1203,6 +1250,7 @@ info += ` / 軍艦: ${warshipNameDisplay} (母港: ${warshipAtTile.homePort}, EX
   document.getElementById('tileInfo').innerHTML = info;
 }
 function selectTile(x, y) {
+  const clickedSelectedTile = selectedX === x && selectedY === y;
   selectedX = x;
   selectedY = y;
   const actionSelect = document.getElementById('actionSelect');
@@ -1210,6 +1258,10 @@ function selectTile(x, y) {
   let action = actionSelect ? actionSelect.value : '';
   if (action === 'warshipTool' && warshipSubSelect) action = warshipSubSelect.value;
   applyAutomaticInputValues(action);
+  if (clickedSelectedTile && action && isSessionSettingEnabled('settingConfirmOnSelectedTileClick') && typeof window.confirmAction === 'function') {
+      window.confirmAction();
+      return;
+  }
   renderMap();
 }
 window.clearTileSelection = function() {
@@ -1338,9 +1390,13 @@ function saveGame() {
         islandSigningKeyPair: JSON.parse(JSON.stringify(islandSigningKeyPair))
     };
     const jsonString = JSON.stringify(gameState);
-    // 新しいエンコード方式 (btoaとencodeURIComponentを組み合わせる)
-    document.getElementById('saveLoadData').value = btoa(encodeURIComponent(jsonString));
-    logAction("ゲームがセーブされました。データをテキストエリアからコピーしてください。");
+    encodeManualSaveText(jsonString).then(encodedData => {
+        document.getElementById('saveLoadData').value = encodedData;
+        logAction("ゲームがMySave形式（gzip圧縮テキスト）で出力されました。データをテキストエリアからコピーしてください。");
+    }).catch(error => {
+        console.error(error);
+        logAction("セーブデータの圧縮に失敗しました。");
+    });
 }
 
 async function loadGame() {
@@ -1350,8 +1406,7 @@ async function loadGame() {
         return;
     }
     try {
-        // 新しいデコード方式
-        const jsonString = decodeURIComponent(atob(encodedData));
+        const jsonString = await decodeManualSaveText(encodedData);
         const gameState = JSON.parse(jsonString);
 
         map = gameState.map;
@@ -4450,12 +4505,10 @@ window.saveGame = async function() {
         volcanoTurns: myIslandState.volcanoTurns
     };
     const jsonString = JSON.stringify(gameState);
-
-    // 文字列をUnicodeコードポイントの配列に変換し、カンマ区切りで結合
-    const encodedData = Array.from(jsonString).map(char => char.charCodeAt(0)).join(',');
+    const encodedData = await encodeManualSaveText(jsonString);
 
     document.getElementById('saveLoadData').value = encodedData;
-    logAction("ゲームがセーブデータとして出力されました。テキストエリアからコピーしてください。");
+    logAction("ゲームがMySave形式（gzip圧縮テキスト）で出力されました。テキストエリアからコピーしてください。");
     updateStatus(); // 島の名前の変更をUIに反映
 }
 
@@ -4468,9 +4521,7 @@ window.loadGame = async function() {
     }
 
     try {
-        // カンマ区切りの文字列をUnicodeコードポイントの配列に戻し、文字列に変換
-        const charCodes = encodedData.split(',').map(Number);
-        const jsonString = String.fromCharCode(...charCodes);
+        const jsonString = await decodeManualSaveText(encodedData);
 
         const gameState = JSON.parse(jsonString);
         map = gameState.map;


### PR DESCRIPTION
### Motivation
- 手動セーブ出力をより短く人が扱いやすい形式にするため、バイト配列ではなくgzip圧縮したテキスト（接頭辞 `MySave:` を付与）に変更する必要があった。 
- 計画一覧で既に選択されているタイルを再クリックしたときに即座に決定できるオプションを追加して操作性を向上させた（デフォルトはオフ）。

### Description
- 手動セーブの新フォーマットとして `MANUAL_SAVE_PREFIX = 'MySave:'` を導入し、gzip 圧縮／展開を行う `gzipText` / `gunzipText` とエンコード／デコード用の `encodeManualSaveText` / `decodeManualSaveText` を `src/main.js` に追加した。 
- 既存の旧フォーマット（カンマ区切りのコードポイント、旧 base64 方式）に対する読み込み互換を `decodeManualSaveText` で保持した。 
- 手動セーブ出力／入力処理 (`saveGame` / `loadGame` と `window.saveGame` / `window.loadGame`) を新フォーマットへ切り替えし、失敗時のエラー処理とログ出力を追加した。 
- セッション設定 `settingConfirmOnSelectedTileClick` を `SESSION_SETTING_DEFAULTS` に追加し、オフをデフォルトに設定した。 
- オフライン版・Supabase(online)版の諸設定ダイアログ（`index.html` と `online.html`）に新しいチェックボックスを追加した。 
- `selectTile(x, y)` を修正し、クリックしたタイルが既に選択済みでかつ `settingConfirmOnSelectedTileClick` が有効な場合に `confirmAction()` を呼び出すようにした。 

### Testing
- `node --check src/main.js` を実行して構文チェックを行い、問題は検出されなかった（成功）。
- Node 上で圧縮／復元のラウンドトリップ確認スニペットを実行して、`MySave:` プレフィックス付き gzip エンコードとデコードの往復が成功することを確認した（成功）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a52e38544d48324b72e71e15e2d3137)