### PR TITLE
軍艦ツールに「残骸破棄」を追加

### DIFF
--- a/Supabase/turn-worker/index.ts
+++ b/Supabase/turn-worker/index.ts
@@ -158,6 +158,7 @@ function runAction(state: any, task: any, outgoing: any[]) {
     else if (action === 'remodelWarshipWeapon' && ship && n(ship.maxAmmo) >= 1000 && n(ship.exp) > 0) { ship.exp = 0; ship.maxAmmo -= 1000; if (task.weaponType === 'torpedo') ship.torpedo = n(ship.torpedo) + 1; else ship.mainGun = n(ship.mainGun) + 1; }
     else if (action === 'enhanceWarship' && ship && n(ship.exp) > 0) { ship.exp = 0; ship.maxDurability = n(ship.maxDurability) + 1; ship.currentDurability = n(ship.currentDurability) + 1; }
     else if (action === 'decommissionWarship' && ship && ship.homePort === state.islandName) state.warships = warships(state).filter((s: any) => s !== ship);
+    else if (action === 'discardWarshipWreckage' && ship && n(ship.currentDurability) <= 0) state.warships = warships(state).filter((s: any) => s !== ship);
     else if (action === 'moveWarshipToDock' && ship) { state.dockedWarships = Array.isArray(state.dockedWarships) ? state.dockedWarships : []; state.dockedWarships.push({ ...ship, isDocked: true, isDispatched: false }); state.warships = warships(state).filter((s: any) => s !== ship); }
     else if (action === 'returnWarshipFromDock') { state.dockedWarships = Array.isArray(state.dockedWarships) ? state.dockedWarships : []; const docked = state.dockedWarships.find((s: any) => s.name === task.name || (n(s.x) === x && n(s.y) === y)); if (docked) { state.dockedWarships = state.dockedWarships.filter((s: any) => s !== docked); warships(state).push({ ...docked, x, y, isDocked: false }); } }
   }

--- a/index.html
+++ b/index.html
@@ -186,6 +186,7 @@ SOFTWARE. -->
   <option value="remodelWarshipWeapon" data-myisland="true">武器換装</option>
   <option value="enhanceWarship" data-myisland="true">軍艦増強</option>
   <option value="decommissionWarship" data-myisland="true">軍艦除籍</option>
+  <option value="discardWarshipWreckage" data-myisland="true">残骸破棄</option>
   <option value="dispatchWarship" data-myisland="true">軍艦派遣</option>
   <option value="requestWarshipReturn" data-myisland="true">軍艦帰還要請</option>
   <option value="emergencyReturn" data-myisland="true">緊急帰還 (80000000G)</option>

--- a/online.html
+++ b/online.html
@@ -133,6 +133,7 @@
   <option value="remodelWarshipWeapon" data-myisland="true">武器換装</option>
   <option value="enhanceWarship" data-myisland="true">軍艦増強</option>
   <option value="decommissionWarship" data-myisland="true">軍艦除籍</option>
+  <option value="discardWarshipWreckage" data-myisland="true">残骸破棄</option>
   <option value="dispatchWarship" data-myisland="true">軍艦派遣</option>
   <option value="requestWarshipReturn" data-myisland="true">軍艦帰還要請</option>
   <option value="moveWarshipToDock" data-myisland="true">船渠へ移動</option>

--- a/src/master.js
+++ b/src/master.js
@@ -745,6 +745,7 @@ function getActionName(action, x, y, extraData) {
     repairWarship: "軍艦修理",
     enhanceWarship: "軍艦増強",
     decommissionWarship: "軍艦除籍",
+    discardWarshipWreckage: "残骸破棄",
     dispatchWarship: "軍艦派遣",
     requestWarshipReturn: "軍艦帰還要請",
     moveWarshipToDock: "船渠へ移動",
@@ -3417,6 +3418,36 @@ window.confirmAction = async function () {
     renderMap();
     updateStatus();
     saveMyIslandState();
+  } else if (action === "discardWarshipWreckage") {
+    if (!targetTileSelected) {
+      logAction(`破棄対象の残骸が配置されているタイルを選択してください。`);
+      return;
+    }
+    const shipIndex = warships.findIndex(
+      (s) => s.x === selectedX && s.y === selectedY,
+    );
+    const ship = warships[shipIndex];
+
+    if (!ship) {
+      logAction(`選択したタイルに軍艦の残骸がありません。`);
+      return;
+    }
+    if (ship.currentDurability > 0) {
+      logAction(`耐久が0の軍艦の残骸のみ破棄できます。`);
+      return;
+    }
+    const confirmation = confirm(
+      `${getWarshipDisplayName(ship)} の残骸を破棄します。資金の返還はありません。よろしいですか？`,
+    );
+    if (confirmation) {
+      warships.splice(shipIndex, 1);
+      logAction(`軍艦 ${getWarshipDisplayName(ship)} の残骸を破棄しました。資金の返還はありません。`);
+      renderMap();
+      updateStatus();
+      saveMyIslandState();
+    } else {
+      logAction(`軍艦 ${getWarshipDisplayName(ship)} の残骸破棄をキャンセルしました。`);
+    }
   } else if (action === "decommissionWarship") {
     if (!targetTileSelected) {
       logAction(`除籍対象の軍艦が配置されているタイルを選択してください。`);


### PR DESCRIPTION
### Motivation
- 海上で撃沈・耐久0になった軍艦の残骸を明示的に除去できるユーザー操作を追加するため。\n
### Description
- 軍艦ツールのサブメニューに `残骸破棄` を追加し、`index.html` と `online.html` の選択肢を拡張しました。\n
- 表示名マップに `discardWarshipWreckage: "残骸破棄"` を追加して計画名を登録しました（`src/master.js`）。\n
- クライアント側の実行処理を `src/master.js` の `confirmAction` に追加し、選択タイルに軍艦が存在し `currentDurability <= 0` の場合は所有者を問わず削除でき、資金の返還は行わない挙動を実装しました（確認ダイアログ付き）。\n
- サーバー側（ターン処理）の実行にも対応させるために `Supabase/turn-worker/index.ts` に `discardWarshipWreckage` の処理分岐を追加し、耐久0以下の軍艦を削除できるようにしました。\n
- 変更ファイル: `src/master.js`, `Supabase/turn-worker/index.ts`, `index.html`, `online.html`。\n
### Testing
- `node --check src/master.js` を実行してクライアントスクリプトの構文チェックは成功しました。\n
- `tsc --noEmit --target ES2020 --module commonjs Supabase/turn-worker/index.ts` を実行しましたが、リモート Deno/ESM の型参照が環境の `tsc` で解決できず失敗しました（環境依存の型解決エラー）。\n
- リポジトリの状態確認のために `git status --short` を実行し、変更ファイルが反映されていることを確認しました。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7bd07876608324af91da28cd42c536)